### PR TITLE
Create package

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,39 @@
+{
+  pkgs ? import (fetchTarball {
+    # nixos-unstable rev 2024-12-03
+    url = "https://github.com/NixOS/nixpkgs/archive/55d15ad12a74eb7d4646254e13638ad0c4128776.tar.gz";
+  }) { },
+}:
+
+pkgs.callPackage (
+  {
+    stdenv,
+    python312Packages,
+    yosys,
+  }:
+  pkgs.stdenv.mkDerivation (finalAttrs: {
+    pname = "rtlil-corpus";
+    version = "1";
+
+    src = builtins.path {
+      name = "rtlil-corpus-source";
+      path = ./.;
+    };
+
+    nativeBuildInputs = [
+      python312Packages.python
+      python312Packages.amaranth
+      yosys
+    ];
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+      mkdir -p "$out"
+      python3 rtlil_from_amaranth_examples.py --amaranth "${finalAttrs.src}/amaranth" --outdir "$out"
+      python3 rtlil_from_vexriscv_sources.py --verilog "${finalAttrs.src}/VexRiscv-verilog" --outdir "$out"
+      runHook postInstall
+    '';
+  })
+) { }

--- a/rtlil_from_amaranth_examples.py
+++ b/rtlil_from_amaranth_examples.py
@@ -5,8 +5,10 @@ import argparse
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Process RTLIL files.")
 parser.add_argument("--outdir", required=True, help="Output directory for generated RTLIL files.")
+parser.add_argument("--amaranth", default="amaranth", required=False, help="Path to amaranth dir.")
 args = parser.parse_args()
 
+amaranth_dir = args.amaranth
 output_dir = args.outdir
 
 # Enable extended debug output
@@ -19,12 +21,12 @@ os.makedirs(output_dir, exist_ok=True)
 
 # List of files to skip
 skip_files = [
-    "amaranth/examples/basic/ctr_en.py",
-    "amaranth/examples/basic/uart.py"
+    f"{amaranth_dir}/examples/basic/ctr_en.py",
+    f"{amaranth_dir}/examples/basic/uart.py"
 ]
 
 # Iterate over all .py files in the directory
-example_dir = "amaranth/examples/basic"
+example_dir = f"{amaranth_dir}/examples/basic"
 for file in os.listdir(example_dir):
     if file.endswith(".py"):
         file_path = os.path.join(example_dir, file)

--- a/rtlil_from_vexriscv_sources.py
+++ b/rtlil_from_vexriscv_sources.py
@@ -5,15 +5,14 @@ import argparse
 # Parse command-line arguments
 parser = argparse.ArgumentParser(description="Process Verilog files to RTLIL format.")
 parser.add_argument("--outdir", required=True, help="Output directory for generated RTLIL files.")
+parser.add_argument("--verilog", default="VexRiscv-verilog", required=False, help="Path to verilog dir.")
 args = parser.parse_args()
 
+verilog_dir = args.verilog
 output_dir = args.outdir
 
 # Ensure the output directory exists
 os.makedirs(output_dir, exist_ok=True)
-
-# Directory containing Verilog files
-verilog_dir = "VexRiscv-verilog"
 
 # Iterate over all .v files in the Verilog directory
 for file in os.listdir(verilog_dir):

--- a/shell.nix
+++ b/shell.nix
@@ -1,12 +1,16 @@
-{ pkgs ? import (fetchTarball {
-  url = "https://github.com/NixOS/nixpkgs/archive/refs/tags/24.05.tar.gz";
-}) {} }:
+{
+  pkgs ? import (fetchTarball {
+    # nixos-unstable rev 2024-12-03
+    url = "https://github.com/NixOS/nixpkgs/archive/55d15ad12a74eb7d4646254e13638ad0c4128776.tar.gz";
+  }) { },
+}:
+
+let
+  rtlil-corpus = pkgs.callPackage ./default.nix { };
+in
 
 pkgs.mkShell {
-  buildInputs = [ 
-    pkgs.python312Packages.amaranth
-    pkgs.yosys
-    ];
+  inputsFrom = [ rtlil-corpus ];
   shellHook = ''
     python3 rtlil_from_amaranth_examples.py --outdir ./corpus
     python3 rtlil_from_vexriscv_sources.py --outdir ./corpus


### PR DESCRIPTION
Updated url rev because 24.05 refers to the initial release of 24.05 which is ancient at this point.

The rev was chosen because my system is on that revision.

Added `--amaranth` and `--verilog` because there were embedded sandbox paths like these in the output files.

`attribute \src "/build/rtlil-corpus-source/amaranth/examples/basic/sel.py:13"`

now they are absolute paths which work outside the sandbox

`attribute \src "/nix/store/0l0z76w8chym09z4vq896plikv1q3r2r-rtlil-corpus-source/amaranth/examples/basic/sel.py:13"`

`nix-shell` still works without needing to pass `--amaranth` or `--verilog`.